### PR TITLE
Update fsc-c.js

### DIFF
--- a/fsc-c.js
+++ b/fsc-c.js
@@ -30,10 +30,20 @@ jQuery(function($) {
       // Uncomment the following 2 lines to display current numbers on screen, given that the page includes two div elements with ids 'left' and 'percent'.
       // $('#left').text(leftPos);
       // $('#percent').text(overlapPercentage + '%');
-			// Qualtrics only: Uncomment the following 2 lines to store the values as Qualtrics embeddedData.
-			// Notice that these embedded data has to be added explicitly in the survey flow in order for them to show up in your data exports.
+	    
+      // Qualtrics only: Uncomment the following 2 lines to store the values as Qualtrics embeddedData
+	    // Notice that these embedded data has to be added explicitly in the survey flow in order for them to show up in your data exports.
       // Qualtrics.SurveyEngine.setEmbeddedData(id + "-distance", leftPos);
       // Qualtrics.SurveyEngine.setEmbeddedData(id + "-overlap", overlapPercentage);
+	    
+      // Qualtrics only: Uncomment the following lines into the survey flow when using multiple measures of self-continuity to send multiple data 
+	    // Otherwise each measure will be sent through same embedded data code and overwritten
+      // Object.entries(circlesData).forEach(([columnId, value]) => {
+      // console.log("we want to send ", value, " to id ", columnId)
+      // Qualtrics.SurveyEngine.setEmbeddedData(columnId, value);
+      //})
+	    
+	    
     }
   });
 });


### PR DESCRIPTION
Qualtrics will overwrite each data code unless it is specifically told to send each object Id to the excel column.

Changes added:
// Qualtrics only: Uncomment the following lines into the survey flow when using multiple measures of self-continuity to send multiple data 
	    // Otherwise each measure will be sent through same embedded data code and overwritten
      // Object.entries(circlesData).forEach(([columnId, value]) => {
      // console.log("we want to send ", value, " to id ", columnId)
      // Qualtrics.SurveyEngine.setEmbeddedData(columnId, value);
      //})